### PR TITLE
updated list method on paymenttype view to return only the authentica…

### DIFF
--- a/bangazonapi/views/paymenttype.py
+++ b/bangazonapi/views/paymenttype.py
@@ -81,7 +81,7 @@ class Payments(ViewSet):
         """Handle GET requests to payment type resource"""
         payment_types = Payment.objects.all()
 
-        customer_id = self.request.query_params.get('customer', None)
+        customer_id = self.request.auth.user.id
 
         if customer_id is not None:
             payment_types = payment_types.filter(customer__id=customer_id)


### PR DESCRIPTION

updated list method on `paymenttypes` view to return only the authenticated user's payment types
## Changes

- updated the line assigning a `customer_id` to the request to access the authenticated user's id

## Requests / Responses

**Request**

GET `/paymenttypes` requests a list of the user's payment types

**Response**

HTTP/1.1 200 SUCCESS
```json
[
    {
        "id": 3,
        "url": "http://localhost:8000/paymenttypes/3",
        "merchant_name": "Visa",
        "account_number": "fj0398fjw0g89434",
        "expiration_date": "2020-03-01",
        "create_date": "2019-03-11"
    }
]
```

## Testing

Description of how to test code...

- [ ] Run GET request on `/paymenttypes` resource


## Related Issues

- Fixes #7 