### PR TITLE
resolved issue for not being able to delete items from cartresolved i…

### DIFF
--- a/bangazonapi/views/lineitem.py
+++ b/bangazonapi/views/lineitem.py
@@ -77,6 +77,7 @@ class LineItems(ViewSet):
         try:
             customer = Customer.objects.get(user=request.auth.user)
             order_product = OrderProduct.objects.get(pk=pk, order__customer=customer)
+            order_product.delete()
 
             return Response({}, status=status.HTTP_204_NO_CONTENT)
 

--- a/bangazonapi/views/profile.py
+++ b/bangazonapi/views/profile.py
@@ -7,7 +7,7 @@ from rest_framework.decorators import action
 from rest_framework.permissions import IsAuthenticatedOrReadOnly
 from rest_framework.response import Response
 from rest_framework.viewsets import ViewSet
-from bangazonapi.models import Order, Customer, Product, OrderProduct, Favorite, payment
+from bangazonapi.models import Order, Customer, Product, OrderProduct, Favorite
 from .product import ProductSerializer
 from .order import OrderSerializer
 

--- a/bangazonapi/views/profile.py
+++ b/bangazonapi/views/profile.py
@@ -7,7 +7,7 @@ from rest_framework.decorators import action
 from rest_framework.permissions import IsAuthenticatedOrReadOnly
 from rest_framework.response import Response
 from rest_framework.viewsets import ViewSet
-from bangazonapi.models import Order, Customer, Product, OrderProduct, Favorite
+from bangazonapi.models import Order, Customer, Product, OrderProduct, Favorite, payment
 from .product import ProductSerializer
 from .order import OrderSerializer
 
@@ -71,7 +71,7 @@ class Profile(ViewSet):
     def cart(self, request):
         """Shopping cart manipulation"""
 
-        current_user = Customer.objects.get(user__id=request.auth.user.id)
+        current_user = Customer.objects.get(user=request.auth.user)
 
         if request.method == "DELETE":
             """
@@ -207,7 +207,7 @@ class Profile(ViewSet):
             """
 
             try:
-                open_order = Order.objects.get(customer=current_user)
+                open_order = Order.objects.get(customer=current_user, payment_type=None)
                 print(open_order)
             except Order.DoesNotExist as ex:
                 open_order = Order()


### PR DESCRIPTION
resolved issue for not being able to delete `lineitems` from the cart

## Changes

- added line 80 in `lineitem` view to delete the order_product
- added `payment_type=None` to POST method on `profile/cart` so I could add an item to delete

## Requests / Responses

**Request**

DELETE `/lineitems/:id` deletes specified `lineitem`

**Response**

HTTP/1.1 204 NO CONTENT

```json
{}
```

## Testing

Description of how to test code...

- [ ] Add a product to cart by performing POST request on `profile/cart`
- [ ] Perform DELETE request at `lineitems/:id` at id of product added


## Related Issues

- Fixes #5 