### PR TITLE
fixed issue with number_sold query not returning the correct response

### DIFF
--- a/bangazonapi/views/product.py
+++ b/bangazonapi/views/product.py
@@ -266,7 +266,7 @@ class Products(ViewSet):
 
         if number_sold is not None:
             def sold_filter(product):
-                if product.number_sold <= int(number_sold):
+                if product.number_sold >= int(number_sold):
                     return True
                 return False
 


### PR DESCRIPTION
## Changes

- Changed the filter method in `product.py` view to display everything `>= number_sold` instead of `<= number_sold`

## Requests / Responses

**Request**

GET `/products?number_sold=2` Displays any product that has sold AT LEAST 2 copies


**Response**

HTTP/1.1 200 SUCCESS

```json
    {
        "id": 50,
        "name": "Escalade EXT",
        "price": 926.92,
        "number_sold": 2,
        "description": "2008 Cadillac",
        "quantity": 2,
        "created_date": "2019-02-01",
        "location": "Lokavec",
        "image_path": null,
        "average_rating": 3.25
    }
```

## Testing

Description of how to test code...

- [ ] Run the request for number_sold at `/products?number_sold=2`
- [ ] Verify that the results match the database 


## Related Issues

- Fixes #4 