### PR TITLE
test to verify deletion of payment

### DIFF
--- a/tests/payments.py
+++ b/tests/payments.py
@@ -41,3 +41,18 @@ class PaymentTests(APITestCase):
         self.assertEqual(json_response["create_date"], str(datetime.date.today()))
 
     # TODO: Delete payment type
+    def test_delete_payment(self):
+        # Create a payment type
+        self.test_create_payment_type()
+        
+        # Delete payment
+        url='/paymenttypes/1'
+        response = self.client.delete(url, None, format="json")
+        
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+
+        # Try to retrieve deleted payment to verify it's deletion
+        url = '/paymenttypes/1'
+        response = self.client.get(url, None, format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_500_INTERNAL_SERVER_ERROR)


### PR DESCRIPTION
Wrote test to verify the deletion of a payment type

## Changes

- wrote `test_delete_payment` in `/tests/payments`

## Requests / Responses


**Request**

DELETE `/paymenttypes/1` deletes specified payment type


**Response**

HTTP/1.1 204 NO CONTENT

```json
{}
```

## Testing

Description of how to test code...

- [ ] Run test suite


## Related Issues

- Fixes #16 